### PR TITLE
Add failing unit test

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
 true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string
 
 "src": include
-<src_test/*.{ml,byte,native}>: debug, package(uint), package(oUnit)
+<src_test/*.{ml,byte,native}>: debug, package(oUnit)

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -6,6 +6,8 @@ let () =
   Pkg.describe "protobuf" ~builder:`OCamlbuild [
     Pkg.lib "pkg/META";
     Pkg.lib ~exts:Exts.module_library "src/protobuf_codec";
+    Pkg.lib ~exts:[".ml"]     "src_test/test_protobuf_codec";
+    Pkg.lib ~exts:[".native"] "src_test/test_protobuf";
     Pkg.doc "README.md";
     Pkg.doc "LICENSE.txt";
     Pkg.doc "CHANGELOG.md"; ]

--- a/src_test/test_protobuf_codec.ml
+++ b/src_test/test_protobuf_codec.ml
@@ -106,8 +106,12 @@ let test_overflow ctxt =
                 (fun () -> Encoder.int32_of_int64 "" 0x1ffffffffL);
   ()
 
+let test_not_overflow ctxt = 
+  assert_equal (- 1) (Decoder.int_of_int64 "" (-1L)) 
+
 let suite = "Test Protobuf_codec" >::: [
     "test_decoder"  >:: test_decoder;
     "test_encoder"  >:: test_encoder;
     "test_overflow" >:: test_overflow;
+    "test_not_overflow" >:: test_not_overflow;
   ]


### PR DESCRIPTION
Add a unit test which is currently failing for me but I believe should work. (negative int64 of reasonable range should be valid int).

I am running this test on my Mac against the github OCaml. I will run this test at work too on Linux. 
