### PR TITLE
Fix varint decode test.  On ints that take up the full number of byte…

### DIFF
--- a/src/protobuf_codec.ml
+++ b/src/protobuf_codec.ml
@@ -108,7 +108,7 @@ module Decoder = struct
       let b = byte d in
       if b land 0x80 <> 0 then
         Int64.(logor (shift_left (logand (of_int b) 0x7fL) s) (read (s + 7)))
-      else if s < 56 || (b land 0x7f) <= 1 then
+      else if s <= 56 || (b land 0x7f) <= 1 then
         Int64.(shift_left (of_int b) s)
       else
         raise (Failure Overlong_varint)


### PR DESCRIPTION
…s they fail saying it is too large

Example:

336138204781163256
